### PR TITLE
Add smart task sorter tool for auto-categorizing tasks

### DIFF
--- a/task-organizer/app.js
+++ b/task-organizer/app.js
@@ -1,0 +1,227 @@
+const form = document.getElementById('task-form');
+const input = document.getElementById('task-input');
+const lists = {
+  house: document.getElementById('house-list'),
+  kitchen: document.getElementById('kitchen-list'),
+  study: document.getElementById('study-list')
+};
+const template = document.getElementById('task-template');
+
+const CATEGORY_MAP = {
+  house: {
+    keywords: [
+      'clean',
+      'vacuum',
+      'laundry',
+      'fold',
+      'organize',
+      'bill',
+      'rent',
+      'utilities',
+      'trash',
+      'garden',
+      'repairs',
+      'declutter',
+      'sweep',
+      'mop',
+      'paint',
+      'fix',
+      'call landlord',
+      'schedule maintenance'
+    ],
+    defaultMessage: 'House looks empty. Add something cozy to tackle!'
+  },
+  kitchen: {
+    keywords: [
+      'cook',
+      'meal',
+      'recipe',
+      'bake',
+      'dinner',
+      'lunch',
+      'breakfast',
+      'grocery',
+      'shop',
+      'produce',
+      'snack',
+      'dishes',
+      'dishwasher',
+      'fridge',
+      'pantry',
+      'meal prep',
+      'wash vegetables',
+      'marinate',
+      'preheat'
+    ],
+    defaultMessage: 'Kitchen is sparkling clean—no tasks here yet.'
+  },
+  study: {
+    keywords: [
+      'study',
+      'class',
+      'course',
+      'assignment',
+      'homework',
+      'read',
+      'review',
+      'exam',
+      'quiz',
+      'resume',
+      'cover letter',
+      'portfolio',
+      'network',
+      'interview',
+      'job',
+      'apply',
+      'application',
+      'linkedin',
+      'practice',
+      'research'
+    ],
+    defaultMessage: 'Line up those ambitions—nothing scheduled yet.'
+  }
+};
+
+const STORAGE_KEY = 'smart-task-sorter';
+
+function sanitizeTask(text) {
+  return text
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function findCategory(taskText) {
+  const normalized = taskText.toLowerCase();
+
+  for (const [category, { keywords }] of Object.entries(CATEGORY_MAP)) {
+    if (keywords.some(keyword => normalized.includes(keyword))) {
+      return category;
+    }
+  }
+
+  // fallback: choose based on first word heuristics
+  const fallback = normalized.split(' ')[0];
+  if (['cook', 'kitchen', 'recipe'].includes(fallback)) return 'kitchen';
+  if (['study', 'course', 'job', 'apply'].includes(fallback)) return 'study';
+  return 'house';
+}
+
+function createTaskElement(task) {
+  const node = template.content.firstElementChild.cloneNode(true);
+  const textEl = node.querySelector('.task-text');
+  textEl.textContent = task.text;
+
+  const removeBtn = node.querySelector('.remove-btn');
+  removeBtn.addEventListener('click', () => {
+    removeTask(task.id);
+  });
+
+  const reclassBtn = node.querySelector('.reclassify-btn');
+  const menu = node.querySelector('.reclassify-menu');
+  reclassBtn.addEventListener('click', () => {
+    menu.classList.toggle('open');
+  });
+
+  menu.querySelectorAll('button').forEach(button => {
+    button.addEventListener('click', () => {
+      menu.classList.remove('open');
+      reclassifyTask(task.id, button.dataset.category);
+    });
+  });
+
+  node.addEventListener('click', event => {
+    if (!node.contains(event.target.closest('.reclassify-btn'))) {
+      menu.classList.remove('open');
+    }
+  });
+
+  return node;
+}
+
+function renderEmptyState(list, message) {
+  const empty = document.createElement('li');
+  empty.className = 'empty-state';
+  empty.textContent = message;
+  list.appendChild(empty);
+}
+
+function render(tasks) {
+  for (const [category, list] of Object.entries(lists)) {
+    list.innerHTML = '';
+    const categoryTasks = tasks.filter(task => task.category === category);
+    if (categoryTasks.length === 0) {
+      renderEmptyState(list, CATEGORY_MAP[category].defaultMessage);
+    } else {
+      const fragment = document.createDocumentFragment();
+      categoryTasks.forEach(task => fragment.appendChild(createTaskElement(task)));
+      list.appendChild(fragment);
+    }
+  }
+}
+
+function loadTasks() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch (error) {
+    console.error('Failed to parse saved tasks', error);
+    return [];
+  }
+}
+
+function saveTasks(tasks) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
+}
+
+function addTask(text) {
+  const task = {
+    id: crypto.randomUUID(),
+    text,
+    category: findCategory(text)
+  };
+  const tasks = loadTasks();
+  tasks.push(task);
+  saveTasks(tasks);
+  render(tasks);
+}
+
+function removeTask(id) {
+  const tasks = loadTasks().filter(task => task.id !== id);
+  saveTasks(tasks);
+  render(tasks);
+}
+
+function reclassifyTask(id, category) {
+  const tasks = loadTasks().map(task => (task.id === id ? { ...task, category } : task));
+  saveTasks(tasks);
+  render(tasks);
+}
+
+form.addEventListener('submit', event => {
+  event.preventDefault();
+  const value = sanitizeTask(input.value);
+  if (!value) return;
+  addTask(value);
+  input.value = '';
+  input.focus();
+});
+
+// Quick keyword helper buttons
+const suggestionContainer = document.querySelector('.suggestion-tags');
+if (suggestionContainer) {
+  suggestionContainer.addEventListener('click', event => {
+    const button = event.target.closest('button');
+    if (!button) return;
+    const keyword = button.dataset.keyword;
+    const baseText = sanitizeTask(input.value);
+    input.value = baseText ? `${baseText} ${keyword}` : keyword;
+    input.focus();
+  });
+}
+
+// Initial render
+const initialTasks = loadTasks();
+render(initialTasks);

--- a/task-organizer/index.html
+++ b/task-organizer/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Smart Task Sorter</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1>Smart Task Sorter</h1>
+    <p>Drop in anything on your mind and we will sort it into House, Kitchen, or Study &amp; Job Search lists for you.</p>
+  </header>
+
+  <main class="app">
+    <section class="input-panel">
+      <h2>Add a task</h2>
+      <form id="task-form" class="task-form">
+        <label class="field-label" for="task-input">What do you need to do?</label>
+        <div class="field-group">
+          <input id="task-input" class="task-input" type="text" placeholder="e.g. Clean the living room" required />
+          <button type="submit" class="primary-btn">Add</button>
+        </div>
+      </form>
+      <div class="helper-text">
+        <p>
+          The sorter looks for keywords such as <strong>laundry, vacuum, dishes, cook, resume, interview</strong> and more.
+          If it cannot guess the task type, you can nudge it with the quick-tag buttons below.
+        </p>
+        <div class="suggestion-tags" aria-label="Quick keywords">
+          <button type="button" data-keyword="vacuum">vacuum</button>
+          <button type="button" data-keyword="meal prep">meal prep</button>
+          <button type="button" data-keyword="grocery">grocery</button>
+          <button type="button" data-keyword="update resume">update resume</button>
+          <button type="button" data-keyword="interview practice">interview practice</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="board" aria-live="polite">
+      <article class="column" data-category="house">
+        <header>
+          <h2>🏠 House</h2>
+          <p class="column-subtitle">Cleaning, maintenance, finances &amp; anything home related.</p>
+        </header>
+        <ul class="task-list" id="house-list"></ul>
+      </article>
+
+      <article class="column" data-category="kitchen">
+        <header>
+          <h2>🍳 Kitchen &amp; Cooking</h2>
+          <p class="column-subtitle">Meal prep, groceries, cooking ideas &amp; chores.</p>
+        </header>
+        <ul class="task-list" id="kitchen-list"></ul>
+      </article>
+
+      <article class="column" data-category="study">
+        <header>
+          <h2>🧠 Study &amp; Job Search</h2>
+          <p class="column-subtitle">Courses, applications, networking, interview prep and more.</p>
+        </header>
+        <ul class="task-list" id="study-list"></ul>
+      </article>
+    </section>
+  </main>
+
+  <template id="task-template">
+    <li class="task-item">
+      <span class="task-text"></span>
+      <div class="task-actions">
+        <button type="button" class="reclassify-btn" aria-haspopup="true">Move</button>
+        <button type="button" class="remove-btn" aria-label="Remove task">✕</button>
+        <div class="reclassify-menu" role="menu">
+          <button type="button" data-category="house">Move to House</button>
+          <button type="button" data-category="kitchen">Move to Kitchen</button>
+          <button type="button" data-category="study">Move to Study &amp; Job Search</button>
+        </div>
+      </div>
+    </li>
+  </template>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/task-organizer/style.css
+++ b/task-organizer/style.css
@@ -1,0 +1,294 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f7fb;
+  --card-bg: #ffffffee;
+  --border: #d4d9e2;
+  --text: #1f2937;
+  --muted: #4b5563;
+  --accent: #2563eb;
+  --accent-strong: #1d4ed8;
+  --shadow: 0 18px 35px -25px rgba(15, 23, 42, 0.45);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: radial-gradient(circle at top left, #e0f2fe, transparent 40%),
+    radial-gradient(circle at bottom right, #ede9fe, transparent 40%),
+    var(--bg);
+  color: var(--text);
+  padding: 2.5rem 1rem 4rem;
+}
+
+.app-header {
+  max-width: 860px;
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.app-header h1 {
+  font-size: clamp(2.25rem, 6vw, 3rem);
+  margin-bottom: 0.5rem;
+}
+
+.app-header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+.app {
+  width: min(1100px, 100%);
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 2rem;
+}
+
+@media (max-width: 960px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+}
+
+.input-panel,
+.column {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(8px);
+}
+
+.input-panel h2 {
+  margin-top: 0;
+  font-size: 1.6rem;
+}
+
+.task-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.field-group {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.task-input {
+  flex: 1;
+  padding: 0.8rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  font-size: 1rem;
+  background: #f8fafc;
+  transition: border-color 0.2s ease;
+}
+
+.task-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.primary-btn {
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 12px;
+  padding: 0.8rem 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.primary-btn:hover,
+.primary-btn:focus {
+  background: var(--accent-strong);
+}
+
+.primary-btn:active {
+  transform: scale(0.98);
+}
+
+.helper-text p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.suggestion-tags {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.suggestion-tags button {
+  border: 1px dashed var(--accent);
+  background: transparent;
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.suggestion-tags button:hover {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.board {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.column header {
+  margin-bottom: 1rem;
+}
+
+.column h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.column-subtitle {
+  margin: 0.4rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.task-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.task-item {
+  background: #f8fafc;
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.task-text {
+  flex: 1;
+  font-size: 1rem;
+}
+
+.task-actions {
+  position: relative;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.reclassify-btn,
+.remove-btn {
+  background: #e2e8f0;
+  border: none;
+  border-radius: 10px;
+  padding: 0.45rem 0.8rem;
+  cursor: pointer;
+  font-weight: 600;
+  color: #1f2937;
+  transition: background 0.2s ease;
+}
+
+.reclassify-btn:hover,
+.remove-btn:hover {
+  background: #cbd5f5;
+}
+
+.remove-btn {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.reclassify-menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  display: none;
+  background: white;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  box-shadow: 0 12px 25px -15px rgba(15, 23, 42, 0.45);
+  min-width: 180px;
+  padding: 0.35rem;
+  z-index: 10;
+}
+
+.reclassify-menu button {
+  display: block;
+  width: 100%;
+  padding: 0.6rem 0.9rem;
+  background: transparent;
+  border: none;
+  text-align: left;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.reclassify-menu button:hover {
+  background: #eff6ff;
+}
+
+.reclassify-menu.open {
+  display: block;
+}
+
+.empty-state {
+  color: var(--muted);
+  font-size: 0.95rem;
+  text-align: center;
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: 12px;
+  padding: 0.7rem 1rem;
+}
+
+.completed {
+  text-decoration: line-through;
+  color: #94a3b8;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f172a;
+    --card-bg: rgba(15, 23, 42, 0.92);
+    --border: rgba(148, 163, 184, 0.25);
+    --text: #e2e8f0;
+    --muted: #94a3b8;
+    --shadow: 0 12px 20px -18px rgba(15, 23, 42, 0.9);
+  }
+
+  body {
+    background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.2), transparent 40%),
+      radial-gradient(circle at bottom right, rgba(30, 64, 175, 0.2), transparent 40%),
+      var(--bg);
+  }
+
+  .task-item {
+    background: rgba(30, 41, 59, 0.8);
+  }
+
+  .reclassify-menu {
+    background: rgba(15, 23, 42, 0.98);
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone Smart Task Sorter page with three category columns
- implement keyword-based task classification with reclassification controls and localStorage persistence
- apply responsive styling, quick keyword helper chips, and dark-mode aware theme

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e3bd6dafc833387cddeffe1adfaac)