### PR TITLE
Add Google Calendar quick add app

### DIFF
--- a/calendar-quick-add/index.html
+++ b/calendar-quick-add/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Calendar Quick Add</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="app">
+    <header>
+      <h1>Calendar Quick Add</h1>
+      <p class="subtitle">
+        Type a natural-language description of your event – including the day and time –
+        and add it to Google Calendar with a single click. You can also review the events
+        already scheduled for the selected day.
+      </p>
+    </header>
+
+    <section class="card auth">
+      <h2>Connect your Google Calendar</h2>
+      <p>
+        Sign in with the Google account whose calendar you want to manage.
+      </p>
+      <div class="button-row">
+        <button id="authorize_button" class="primary">Sign in with Google</button>
+        <button id="signout_button" class="secondary" hidden>Sign out</button>
+      </div>
+      <p id="auth_status" class="helper-text"></p>
+    </section>
+
+    <section class="card quick-add">
+      <h2>Quick-add an event</h2>
+      <label for="event_text" class="field-label">Event message</label>
+      <textarea id="event_text" rows="3" placeholder="E.g. 'Coffee with Lee tomorrow at 9am at Blue Bottle'" disabled></textarea>
+      <button id="quick_add_button" class="primary" disabled>Add to calendar</button>
+      <p id="quick_add_status" class="helper-text" role="status" aria-live="polite"></p>
+    </section>
+
+    <section class="card upcoming">
+      <div class="section-header">
+        <h2>Events on a specific day</h2>
+        <div class="date-picker">
+          <label for="event_date" class="field-label">Choose a day</label>
+          <input type="date" id="event_date" disabled />
+        </div>
+      </div>
+      <button id="refresh_button" class="secondary" disabled>Refresh events</button>
+      <ul id="events_list" class="events-list" aria-live="polite"></ul>
+    </section>
+
+    <section class="card help">
+      <h2>Getting started</h2>
+      <p>
+        This page uses the Google Calendar API. Before it can add or read events,
+        you need to create OAuth credentials in the Google Cloud Console and enable the
+        Calendar API for your project.
+      </p>
+      <details>
+        <summary>Configure Google Cloud credentials</summary>
+        <ol>
+          <li>Visit <a href="https://console.cloud.google.com/apis/dashboard" target="_blank" rel="noopener">Google Cloud Console</a>.</li>
+          <li>Create (or select) a project and enable the <strong>Google Calendar API</strong>.</li>
+          <li>Generate an <strong>OAuth client ID</strong> for a web application and add <code>http://localhost</code> (or your deployment URL) to the list of authorized origins.</li>
+          <li>Create an <strong>API key</strong> for the same project.</li>
+          <li>Replace the <code>CLIENT_ID</code> and <code>API_KEY</code> placeholders in <code>script.js</code> with your credentials.</li>
+        </ol>
+        <p class="helper-text">
+          Never commit real credentials to version control. For production use,
+          consider loading them from environment variables or a secure vault.
+        </p>
+      </details>
+      <p>
+        After you sign in, type a message that includes the event date and time. The app
+        uses Google Calendar's Quick Add feature to interpret the text.
+      </p>
+    </section>
+  </main>
+
+  <script src="https://apis.google.com/js/api.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/calendar-quick-add/script.js
+++ b/calendar-quick-add/script.js
@@ -1,0 +1,269 @@
+const CLIENT_ID = 'YOUR_GOOGLE_OAUTH_CLIENT_ID';
+const API_KEY = 'YOUR_GOOGLE_API_KEY';
+const DISCOVERY_DOC = 'https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest';
+const SCOPES = 'https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.events.readonly';
+
+const authorizeButton = document.getElementById('authorize_button');
+const signoutButton = document.getElementById('signout_button');
+const eventText = document.getElementById('event_text');
+const quickAddButton = document.getElementById('quick_add_button');
+const quickAddStatus = document.getElementById('quick_add_status');
+const authStatus = document.getElementById('auth_status');
+const dateInput = document.getElementById('event_date');
+const refreshButton = document.getElementById('refresh_button');
+const eventsList = document.getElementById('events_list');
+
+let authInstance = null;
+
+function credentialsConfigured() {
+  const missingClient = !CLIENT_ID || CLIENT_ID.includes('YOUR_GOOGLE_OAUTH_CLIENT_ID');
+  const missingKey = !API_KEY || API_KEY.includes('YOUR_GOOGLE_API_KEY');
+  if (missingClient || missingKey) {
+    setAuthStatus('Add your Google API credentials to script.js to enable sign-in.', 'warning');
+    authorizeButton.disabled = true;
+    return false;
+  }
+  authorizeButton.disabled = false;
+  return true;
+}
+
+gapi.load('client:auth2', initClient);
+
+authorizeButton.addEventListener('click', () => {
+  if (!authInstance) {
+    setAuthStatus('Google client not ready yet. Please wait a moment and try again.', 'error');
+    return;
+  }
+  authInstance.signIn();
+});
+
+signoutButton.addEventListener('click', () => {
+  if (authInstance) {
+    authInstance.signOut();
+  }
+});
+
+quickAddButton.addEventListener('click', handleQuickAdd);
+refreshButton.addEventListener('click', fetchEventsForSelectedDay);
+eventText.addEventListener('input', () => {
+  if (!eventText.disabled) {
+    quickAddButton.disabled = eventText.value.trim().length === 0;
+  }
+});
+
+dateInput.addEventListener('change', () => {
+  if (!dateInput.disabled) {
+    fetchEventsForSelectedDay();
+  }
+});
+
+async function initClient() {
+  if (!credentialsConfigured()) {
+    return;
+  }
+
+  try {
+    await gapi.client.init({
+      apiKey: API_KEY,
+      clientId: CLIENT_ID,
+      discoveryDocs: [DISCOVERY_DOC],
+      scope: SCOPES,
+    });
+    authInstance = gapi.auth2.getAuthInstance();
+    updateSigninStatus(authInstance.isSignedIn.get());
+    authInstance.isSignedIn.listen(updateSigninStatus);
+    setAuthStatus('Ready to sign in. Click the button above to connect your Google account.', 'info');
+  } catch (err) {
+    console.error('Error initializing Google API client', err);
+    setAuthStatus('Unable to initialize the Google API client. Check the console for details.', 'error');
+  }
+}
+
+function updateSigninStatus(isSignedIn) {
+  if (isSignedIn) {
+    authorizeButton.hidden = true;
+    signoutButton.hidden = false;
+    setAuthStatus('Connected to Google Calendar.', 'success');
+    enableAppControls();
+    fetchEventsForSelectedDay();
+  } else {
+    authorizeButton.hidden = false;
+    signoutButton.hidden = true;
+    setAuthStatus('You are signed out. Sign in to manage your calendar.', 'info');
+    disableAppControls();
+    clearEventsList();
+  }
+}
+
+function enableAppControls() {
+  eventText.disabled = false;
+  dateInput.disabled = false;
+  refreshButton.disabled = false;
+  if (!dateInput.value) {
+    const today = new Date();
+    dateInput.value = today.toISOString().split('T')[0];
+  }
+  quickAddButton.disabled = eventText.value.trim().length === 0;
+}
+
+function disableAppControls() {
+  eventText.disabled = true;
+  quickAddButton.disabled = true;
+  dateInput.disabled = true;
+  refreshButton.disabled = true;
+  setQuickAddStatus('');
+}
+
+async function handleQuickAdd() {
+  const text = eventText.value.trim();
+  if (!text) {
+    return;
+  }
+
+  setQuickAddStatus('Adding event…', 'info');
+  quickAddButton.disabled = true;
+
+  try {
+    const response = await gapi.client.calendar.events.quickAdd({
+      calendarId: 'primary',
+      text,
+      sendUpdates: 'none',
+    });
+
+    eventText.value = '';
+    setQuickAddStatus(`Added “${response.result.summary}”.`, 'success');
+    fetchEventsForSelectedDay();
+  } catch (err) {
+    console.error('Quick Add failed', err);
+    const message = err.result?.error?.message || 'Unable to add the event. Please try again.';
+    setQuickAddStatus(message, 'error');
+  } finally {
+    quickAddButton.disabled = eventText.value.trim().length === 0;
+  }
+}
+
+async function fetchEventsForSelectedDay() {
+  if (dateInput.disabled || !dateInput.value) {
+    return;
+  }
+
+  setEventsListLoading();
+
+  const start = new Date(`${dateInput.value}T00:00:00`);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+
+  try {
+    const response = await gapi.client.calendar.events.list({
+      calendarId: 'primary',
+      singleEvents: true,
+      orderBy: 'startTime',
+      timeMin: start.toISOString(),
+      timeMax: end.toISOString(),
+      showDeleted: false,
+    });
+
+    renderEvents(response.result.items || []);
+  } catch (err) {
+    console.error('Fetching events failed', err);
+    eventsList.innerHTML = '<li class="empty-state">Unable to load events. Check the console for details.</li>';
+  }
+}
+
+function renderEvents(events) {
+  eventsList.innerHTML = '';
+
+  if (!events.length) {
+    eventsList.innerHTML = '<li class="empty-state">No events scheduled for this day.</li>';
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  events.forEach((event) => {
+    const li = document.createElement('li');
+
+    const title = document.createElement('div');
+    title.className = 'event-title';
+    title.textContent = event.summary || 'Untitled event';
+
+    const time = document.createElement('div');
+    time.className = 'event-time';
+    time.textContent = formatEventTime(event);
+
+    const location = document.createElement('div');
+    location.className = 'event-location';
+    if (event.location) {
+      location.textContent = event.location;
+    }
+
+    li.append(title, time);
+
+    if (event.location) {
+      li.appendChild(location);
+    }
+
+    if (event.hangoutLink) {
+      const meetingLink = document.createElement('a');
+      meetingLink.href = event.hangoutLink;
+      meetingLink.target = '_blank';
+      meetingLink.rel = 'noopener';
+      meetingLink.textContent = 'Join meeting';
+      li.appendChild(meetingLink);
+    }
+
+    fragment.appendChild(li);
+  });
+
+  eventsList.appendChild(fragment);
+}
+
+function formatEventTime(event) {
+  const { start, end } = event;
+  if (!start) {
+    return 'Time unavailable';
+  }
+
+  const startDate = start.dateTime ? new Date(start.dateTime) : new Date(start.date);
+  const endDate = end?.dateTime ? new Date(end.dateTime) : end?.date ? new Date(end.date) : null;
+
+  if (!start.dateTime) {
+    return 'All-day event';
+  }
+
+  const timeFormatter = new Intl.DateTimeFormat([], {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+  const dateFormatter = new Intl.DateTimeFormat([], {
+    month: 'short',
+    day: 'numeric',
+  });
+
+  const startStr = `${dateFormatter.format(startDate)} · ${timeFormatter.format(startDate)}`;
+
+  if (endDate) {
+    const endStr = timeFormatter.format(endDate);
+    return `${startStr} – ${endStr}`;
+  }
+
+  return startStr;
+}
+
+function setQuickAddStatus(message, state = 'info') {
+  quickAddStatus.textContent = message;
+  quickAddStatus.dataset.state = state;
+}
+
+function setAuthStatus(message, state = 'info') {
+  authStatus.textContent = message;
+  authStatus.dataset.state = state;
+}
+
+function setEventsListLoading() {
+  eventsList.innerHTML = '<li class="empty-state">Loading events…</li>';
+}
+
+function clearEventsList() {
+  eventsList.innerHTML = '';
+}

--- a/calendar-quick-add/styles.css
+++ b/calendar-quick-add/styles.css
@@ -1,0 +1,223 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-size: 16px;
+  --bg-color: #0f172a;
+  --card-bg: rgba(15, 23, 42, 0.6);
+  --card-border: rgba(148, 163, 184, 0.3);
+  --text-color: #e2e8f0;
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --muted: #94a3b8;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.12), transparent 55%),
+              radial-gradient(circle at bottom, rgba(59, 130, 246, 0.12), transparent 60%),
+              var(--bg-color);
+  min-height: 100vh;
+}
+
+body {
+  margin: 0;
+  color: var(--text-color);
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem 4rem;
+}
+
+.app {
+  width: min(900px, 100%);
+  display: grid;
+  gap: 1.5rem;
+}
+
+header {
+  text-align: center;
+  padding: 1rem;
+}
+
+h1 {
+  margin-bottom: 0.25rem;
+  font-size: clamp(2rem, 5vw, 2.75rem);
+}
+
+h2 {
+  margin-top: 0;
+  font-size: 1.4rem;
+}
+
+.subtitle {
+  margin: 0 auto;
+  max-width: 600px;
+  color: var(--muted);
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  padding: 1.75rem;
+  backdrop-filter: blur(16px);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+}
+
+.card p {
+  margin-top: 0.25rem;
+}
+
+.button-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+button {
+  font: inherit;
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #0f172a;
+  font-weight: 600;
+  box-shadow: 0 10px 20px rgba(14, 165, 233, 0.25);
+}
+
+button.primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 25px rgba(14, 165, 233, 0.35);
+}
+
+button.secondary {
+  background: transparent;
+  color: var(--text-color);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+button.secondary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(148, 163, 184, 0.2);
+}
+
+textarea,
+input[type="date"] {
+  width: 100%;
+  margin-top: 0.75rem;
+  font: inherit;
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 12px;
+  color: var(--text-color);
+  padding: 0.75rem 1rem;
+  box-sizing: border-box;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+textarea:focus,
+input[type="date"]:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+}
+
+.field-label {
+  display: block;
+  font-weight: 600;
+}
+
+.helper-text {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.helper-text[data-state="success"] {
+  color: #4ade80;
+}
+
+.helper-text[data-state="error"] {
+  color: #f87171;
+}
+
+.helper-text[data-state="warning"] {
+  color: #fbbf24;
+}
+
+.helper-text[data-state="info"] {
+  color: var(--muted);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.events-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.25rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.events-list li {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.events-list .event-title {
+  font-weight: 600;
+}
+
+.events-list .event-time {
+  font-weight: 600;
+}
+
+.events-list .event-location {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.events-list a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.events-list a:hover {
+  text-decoration: underline;
+}
+
+.empty-state {
+  color: var(--muted);
+  text-align: center;
+  padding: 1rem 0;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .card {
+    padding: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- create a standalone Calendar Quick Add page that authenticates with Google and calls the Calendar API
- enable quick-add messaging for natural language events and display the day's schedule
- document the Google Cloud credentials required to run the tool

## Testing
- not run (static files)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ec7cea49483339450fbcdd65c3545)